### PR TITLE
Add option to listen on general channel

### DIFF
--- a/lib/gynoid.js
+++ b/lib/gynoid.js
@@ -62,6 +62,10 @@ Gynoid.prototype.reloadDroid = function(name) {
 
 Gynoid.prototype.registerDroid = function(name, token) {
   var gynoid = this;
+  var config = gynoid.configuration.read();
+  var allowGeneralKey = 'ALLOW_GENERAL_POST';
+  var allowGeneral = config.keys[name] && config.keys[name][allowGeneralKey] && (config.keys[name][allowGeneralKey] === 'allow');
+
   return new Promise(function (resolve, reject) {
     gynoid.configuration.saveDroid(name, { token: token, extensions: []});
     var droid = {
@@ -72,7 +76,12 @@ Gynoid.prototype.registerDroid = function(name, token) {
     };
 
     // By convention, we don't allow bots in General
-    droid.listener.ignore('#general');
+    if (!allowGeneral) {
+      droid.listener.ignore('#general');
+    } else {
+      console.log('Detected ' + allowGeneralKey + ' setting for droid ' + name + '. Allowing listening and posting to #general');
+    }
+
     droid.listener.on('error', function (err) {
       // print to stderr, or sent to error reporting service
       // TODO: Send error messages and audit logs using a log droid


### PR DESCRIPTION
To enable listen to #general need to talk gynoid:
1. `add key ALLOW_GENERAL_POST allow to {bot-name}`
1. `reload {bot-name}`
